### PR TITLE
Properly generate links when specified source path doesn't end in '/'

### DIFF
--- a/lib/utils/Workspace.js
+++ b/lib/utils/Workspace.js
@@ -53,7 +53,7 @@
                     fullPath: data[0],
                     path: data[1],
                     name: data[2],
-                    docPath: data[1].replace(src, "")
+                    docPath: data[1].replace(src, "").replace(/^\//, "")
                 };
             });
             


### PR DESCRIPTION
Currently, if you specify the source folder on the command line without a trailing slash (e.g. `documenter --source /Users/nj/github/brackets/src ...`, the module links in the generated index file are incorrect (they have an extra /). This pull request strips the beginning slash off the document path stored for each module, which seems to be the assumption other parts of the code are making.
