### PR TITLE
Sort dependencies by name

### DIFF
--- a/lib/language/js/ModuleParser.js
+++ b/lib/language/js/ModuleParser.js
@@ -133,7 +133,7 @@
                 }
             });
             
-            module.dependencies = _sortMembers(module.dependencies, "name");
+            module.dependencies = _sortMembers(module.dependencies, function (el) { return el.name.toLowerCase(); });
             module.variables = _sortMembers(module.variables);
             module.functions = _sortMembers(module.functions);
             module.classes = _.toArray(module.classes).map(function (clazz) {


### PR DESCRIPTION
This is for #8. I don't like this solution as much as PR #12 because this is a case-sensitive sort, but I can't see any way to do a case-insensitive sort with underscore. This is probably good enough.
