### PR TITLE
Escape 'type'

### DIFF
--- a/lib/language/js/GoogleClosureProcessor.js
+++ b/lib/language/js/GoogleClosureProcessor.js
@@ -11,6 +11,8 @@
 
     "use strict";
 
+    var _           = require("underscore")._;
+
     /**
      * A custom comment post-processor for Closure Compiler support
      * @param {Object} data Raw data of the module being processed
@@ -29,7 +31,7 @@
             PARAM_FUNCTION_REGEXP       = new RegExp("^function\\((.*)\\)$"),
             PARAM_NULLABLE_REGEXP       = new RegExp("^\\?(.*)$"),
             PARAM_NON_NULLABLE_REGEXP   = new RegExp("^!(.*)$"),
-            PARAM_OPTIONAL_REGEXP   = new RegExp("^(.*)=$");
+            PARAM_OPTIONAL_REGEXP       = new RegExp("^(.*)=$");
 
         var types = tag.types.join(', '),
             match;
@@ -45,7 +47,7 @@
             tag.modifiers.push('non-nullable');
             tag.types = match[1];
         }
-        
+
         match = PARAM_OPTIONAL_REGEXP.exec(types);
         if (match) {
             tag.modifiers.push('optional');
@@ -81,7 +83,7 @@
                 if (tag.type === 'type') {
                     return {
                         key: "Type",
-                        value: tag.types.join(", ")
+                        value: _.escape(tag.types.join(", "))
                     };
                 } else if (tag.type === "see") {
                     return {

--- a/lib/language/js/ModuleParser.js
+++ b/lib/language/js/ModuleParser.js
@@ -97,9 +97,8 @@
                     
                     if (context.type === "declaration") {
                         module.variables.push(comment);
-                    }
-                    
-                    if (context.type === "function") {
+
+                    } else if (context.type === "function") {
                         
                         if (comment.isConstructor) {
                             
@@ -114,13 +113,11 @@
                             module.functions.push(comment);
                             
                         }
-                    }
-                    
-                    if (context.type === "method" && module.classes[context.constructor]) {
+
+                    } else if (context.type === "method" && module.classes[context.constructor]) {
                         module.classes[context.constructor].methods.push(comment);
-                    }
-                    
-                    if (context.type === "property" && module.classes[context.constructor]) {
+
+                    } else if (context.type === "property" && module.classes[context.constructor]) {
                         module.classes[context.constructor].properties.push(comment);
                     }
                     


### PR DESCRIPTION
This is for #11 

We can't change the template field from {{{ }}} to {{ }} because one of the other uses is for links.
