### PR TITLE
Update dox version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies" : {
         "commander" : "1.1.x",
         "deferred"  : "0.6.x",
-        "dox"       : "https://github.com/jbalsas/dox/tarball/master",
+        "dox"       : "https://github.com/jbalsas/dox/tarball/jbalsas/update_0.4.4",
         "find"      : "0.1.4",
         "filequeue" : "0.1.x",
         "fmerge"    : "1.0.x",


### PR DESCRIPTION
Hey @redmunds , 

This is a fix for #28 

It points to an updated version of dox to 0.4.4 which also adds some additional patches to the ones the provide and the others we had. To test this out, just remove your `node_modules` folder and run `npm install` inside the apify folder to grab the new dox dependency.
