### PR TITLE
The left-section and module panes should scroll separately

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -11,6 +11,11 @@ body {
   background-color: #F8F8F8;
 }
 
+.module, .left-section {
+    overflow-y: auto;
+    height: calc(100vh - 195px);
+}
+
 a {
   color: #0083e8;    
 }


### PR DESCRIPTION
@jbalsas This is the first draft of a fix for #23.

The scrolling part works good in Chrome on Win7, but that's the only testing I've done.

One issue with this is that following a link to a different module forgets the scrolling in the left-section. Is that OK? All of the ways I could think to handle that seemed like a lot of work or too clunky, so I just wanted to post this to get your thoughts.
