### PR TITLE
Update dox dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies" : {
         "commander" : "1.1.x",
         "deferred"  : "0.6.x",
-        "dox"       : "https://github.com/jbalsas/dox/tarball/jbalsas/update_0.4.4",
+        "dox"       : "https://github.com/jbalsas/dox/tarball/dox_apify_0.1",
         "find"      : "0.1.4",
         "filequeue" : "0.1.x",
         "fmerge"    : "1.0.x",


### PR DESCRIPTION
Hey @redmunds this is the fix for #52 and superseeds #68 

We just need to update the `dox` dependency here to the new branch, we don't really need to change apify for this.

I refactored the previous solution to make it more reusable and consistent. The whole philosophy of `dox` is quite fragile though, and we'll keep seeing this kind of issues, so I've been checking to see if we can move to `esprima` at some point, but I want to keep pushing changes in the meantime ;)

This should fix the last couple of issues you mentioned [here](https://github.com/jbalsas/apify/pull/68#issuecomment-45971615)
