### PR TITLE
Also use context.receiver to assign methods and properties

### DIFF
--- a/lib/language/js/ModuleParser.js
+++ b/lib/language/js/ModuleParser.js
@@ -107,6 +107,7 @@
                 var context = comment.ctx;
                 
                 if (context) {
+                    var receiver = context.receiver || context.constructor;
                     
                     if (context.type === "declaration") {
                         module.variables.push(comment);
@@ -127,11 +128,11 @@
                             
                         }
 
-                    } else if (context.type === "method" && module.classes[context.constructor]) {
-                        module.classes[context.constructor].methods.push(comment);
+                    } else if (context.type === "method" && module.classes[receiver]) {
+                        module.classes[receiver].methods.push(comment);
 
-                    } else if (context.type === "property" && module.classes[context.constructor]) {
-                        module.classes[context.constructor].properties.push(comment);
+                    } else if (context.type === "property" && module.classes[receiver]) {
+                        module.classes[receiver].properties.push(comment);
                     }
                     
                 } else {


### PR DESCRIPTION
Hey @redmunds, @lkcampbell, this is a possible fix for #74. We were missing the receiver object, so we weren't pushing those properties and methods to the appropriate object.

Great catch! Thanks!
