### PR TITLE
Update dox_apify version to remove leading hyphen in @param description

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies" : {
         "commander" : "1.1.x",
         "deferred"  : "0.6.x",
-        "dox"       : "https://github.com/jbalsas/dox/tarball/dox_apify_0.2",
+        "dox"       : "https://github.com/jbalsas/dox/tarball/dox_apify_0.4",
         "find"      : "0.1.4",
         "filequeue" : "0.1.x",
         "fmerge"    : "1.0.x",


### PR DESCRIPTION
Fix for #83 from https://github.com/jbalsas/dox/commit/058610cbd0bb7e55a7148ca9ae81c7652712b751
